### PR TITLE
Update route for Openshift 4.10

### DIFF
--- a/two-pizza-team-centos.yaml
+++ b/two-pizza-team-centos.yaml
@@ -85,7 +85,7 @@ spec:
           - containerPort: 8080
             name: pepperoni-pizza
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/two-pizza-team-fedora.yaml
+++ b/two-pizza-team-fedora.yaml
@@ -83,7 +83,7 @@ spec:
           - containerPort: 8080
             name: pepperoni-pizza
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/two-pizza-team-rhel.yaml
+++ b/two-pizza-team-rhel.yaml
@@ -85,7 +85,7 @@ spec:
           - containerPort: 8080
             name: pepperoni-pizza
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/two-pizza-team-ubi.yaml
+++ b/two-pizza-team-ubi.yaml
@@ -85,7 +85,7 @@ spec:
           - containerPort: 8080
             name: pepperoni-pizza
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:


### PR DESCRIPTION
The short apiVersion without the Group produces a deprecation warning in the latest releases.

![image](https://user-images.githubusercontent.com/86437966/200026864-3562ca96-7e43-4c87-ba78-1fbf36f88c54.png)
